### PR TITLE
Some fixes for chapter 2

### DIFF
--- a/ch2.md
+++ b/ch2.md
@@ -773,7 +773,7 @@ function findPropIn(propName,obj) {
 }
 ```
 
-```
+```js
 // async recursion:
 setTimeout( function waitForIt(){
 	// does `it` exist yet?
@@ -784,7 +784,7 @@ setTimeout( function waitForIt(){
 }, 100 );
 ```
 
-```
+```js
 // event handler unbinding
 document.getElementById( "onceBtn" )
 	.addEventListener( "click", function handleClick(evt){
@@ -803,7 +803,6 @@ Moreover, even in simple cases with one-liner functions, naming them tends to ma
 people.map( function getPreferredName(person){
 	return person.nicknames[0] || person.firstName;
 } )
-..
 ```
 
 The function name `getPreferredName(..)` tells the reader something about what the mapping operation is intending to do that is not entirely obvious from just its code. This name label helps the code be more readable.
@@ -850,7 +849,7 @@ Compare:
 people.map( function getPreferredName(person){
 	return person.nicknames[0] || person.firstName;
 } )
-..
+
 
 people.map( person => person.nicknames[0] || person.firstName );
 ```
@@ -950,7 +949,7 @@ var Auth = {
 			else this.displaySuccess();
 		} );
 	},
-	send(..) {
+	send(...args) {
 		// ..
 	}
 };
@@ -979,7 +978,7 @@ In case you're having trouble parsing what this code does: we have two separate 
 ```js
 // ..
 
-authorize(ctx) {
+function authorize(ctx) {
 	var credentials = ctx.username + ":" + ctx.password;
 	Auth.send( credentials, function onResp(resp){
 		if (resp.error) ctx.displayError( resp.error );
@@ -989,7 +988,7 @@ authorize(ctx) {
 
 // ..
 
-doLogin(user,pw) {
+function doLogin(user,pw) {
 	Auth.authorize( {
 		username: user,
 		password: pw


### PR DESCRIPTION
Some fixes for chapter 2.
Mostly syntax errors that made examples non-copy-pastable in a console and a few code blocks that were not marked a JavaScript.