### PR TITLE
Recommend some fixes related to Observables

### DIFF
--- a/ch9.md
+++ b/ch9.md
@@ -286,7 +286,7 @@ Here's our earlier reactive example, expressed with Observables instead of `Lazy
 var a = new Rx.Subject();
 
 setInterval( function everySecond(){
-	a.onNext( Math.random() );
+	a.next( Math.random() );
 }, 1000 );
 
 
@@ -302,7 +302,7 @@ b.subscribe( function onValue(v){
 } );
 ```
 
-In the RxJS universe, an Observer subscribes to an Observable. If you combine the functionality of an Observer and an Observable, you get a Subject. So, to keep our snippet simpler, we construct `a` as a Subject, so that we can call `onNext(..)` on it to push values (events) into its stream.
+In the RxJS universe, an Observer subscribes to an Observable. If you combine the functionality of an Observer and an Observable, you get a Subject. So, to keep our snippet simpler, we construct `a` as a Subject, so that we can call `next(..)` on it to push values (events) into its stream.
 
 If we want to keep the Observer and Observable separate:
 
@@ -311,14 +311,14 @@ If we want to keep the Observer and Observable separate:
 
 // producer:
 
-var a = Rx.Observable.create( function onObserver(observer){
+var a = Rx.Observable.create( function onObserve(observer){
 	setInterval( function everySecond(){
-		a.onNext( Math.random() );
+		observer.next( Math.random() );
 	}, 1000 );
 } );
 ```
 
-In this snippet, `a` is the Observable, and unsurprisingly, the separate observer is called `observer`; it's able to "observe" some events (like our `setInterval(..)` loop) and publish events to the `a` observable stream.
+In this snippet, `a` is the Observable, and unsurprisingly, the separate observer is called `observer`; it's able to "observe" some events (like our `setInterval(..)` loop) and ~~publish events to the `a` observable stream~~.
 
 In addition to `map(..)`, RxJS defines well over a hundred operators that are invoked lazily as each new value comes in. Just like with arrays, each operator on an Observable returns a new Observable, meaning they are chainable. If an invocation of operator function determines a value should be passed along from the input Observable, it will be fired on the output Observable; otherwise it's discarded.
 


### PR DESCRIPTION
No, I didn't read the [Contributions Guidelines](CONTRIBUTING.md). You can close this PR if you want, I'm just sending it as message. Twitter would have been a worse medium. :)

I renamed `onNext` to `next` since `onNext` is RxJS v4 terminology, while `next` is RxJS v5 and TC39 Observable terminology. Also, a fundamental mistake was to do `a.onNext` inside Observable.create. `next()` is a function in Observers. I think a better explanation would be to introduce Observable and Observer first, and then Subject later, since a Subject is just both Observable and Observer. Think Observable as read-only, and Observer as write-only. Subject is read and write. I highly recommend watching this https://www.youtube.com/watch?v=uQ1zhJHclvs&feature=youtu.be. But so far, good explanations and the path from eager map to lazy map is cool. Anyway, just my 2 cents on this topic.