### PR TITLE
fix for naming longEnoughReducer as shortEnoughReducer

### DIFF
--- a/apA.md
+++ b/apA.md
@@ -318,7 +318,7 @@ Remember, if we wanted the independent reducers from all these, we could do:
 
 ```js
 var upperReducer = x( listCombination );
-var shortEnoughReducer = y( listCombination );
+var longEnoughReducer = y( listCombination );
 var shortEnoughReducer = z( listCombination );
 ```
 


### PR DESCRIPTION
**Yes, I promise I've read the [Contributions Guidelines](https://github.com/getify/Functional-Light-JS/blob/master/CONTRIBUTING.md)** (please feel free to remove this line *IF YOU ACTUALLY READ THEM*).
