### PR TITLE
ch9: fix a code bug for the flatten

### DIFF
--- a/ch9.md
+++ b/ch9.md
@@ -596,7 +596,7 @@ var flatten =
     arr =>
         arr.reduce(
             (list,v) =>
-                [ ...list, Array.isArray( v ) ? flatten( v ) : v ]
+                [ ...list, ...Array.isArray( v ) ? flatten( v ) : [v] ]
         , [] );
 ```
 
@@ -617,12 +617,10 @@ var flatten =
         arr.reduce(
             (list,v) =>
                 [ ...list,
-                    depth > 0 ?
-                        (depth > 1 && Array.isArray( v ) ?
+                    ...
+                        depth >= 1 && Array.isArray( v ) ?
                             flatten( v, depth - 1 ) :
-                            v
-                        ) :
-                        [v]
+                            [v]
                 ]
         , [] );
 ```


### PR DESCRIPTION
**Yes, I promise I've read the [Contributions Guidelines](https://github.com/getify/Functional-Light-JS/blob/master/CONTRIBUTING.md)** (please feel free to remove this line *IF YOU ACTUALLY READ THEM*).

This sentence can not make the value flattened properly, because the result won't be flattened automatically.
```
[ ...list, Array.isArray( v ) ? flatten( v ) : v ]
```

Maybe we can use spread operator to the flatten(v) like below, but it will have syntax errors. Like the function return, we can not return multiple values for an expression.
```
[ ...list, ...(Array.isArray( v ) ? ...(flatten( v )) : v ]
```

We can also try to put spread operator here, but it will cause errors when the v is not an array.
```
[ ...list, ...(Array.isArray( v ) ? flatten( v ) : v) ]
```


So,  we need to change v to an array. got this
```
[ ...list, ...(Array.isArray( v ) ? flatten( v ) : [v]) ]
```

And because ... has the lowest precedence(https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Operator_Precedence), we can write like this:
```
 [ ...list, ...Array.isArray( v ) ? flatten( v ) : [v] ]
```
