### PR TITLE
Change wring variable reference

### DIFF
--- a/manuscript/ch5.md
+++ b/manuscript/ch5.md
@@ -206,7 +206,7 @@ function fetchOrders(userId) {
             for (let order of orders) {
                 // keep a reference to latest order for each user
                 users[userId].latestOrder = order;
-                userOrders[orders[i].orderId] = order;
+                userOrders[order.orderId] = order;
             }
         }
     );


### PR DESCRIPTION
In chapter 5 wrong line was replaced:
```javascript
userOrders[orders[i].orderId] = order;
// By
userOrders[order.orderId] = order;
```
