### PR TITLE
fix random range for stock index

### DIFF
--- a/ch11-code/mock-server.js
+++ b/ch11-code/mock-server.js
@@ -41,7 +41,7 @@ setTimeout( function initialStocks(){
 
 setTimeout( function randomStockUpdate(){
 	var stockIds = Object.keys( stocks );
-	var stockIdx = randInRange( 0, stockIds.length - 1 );
+	var stockIdx = randInRange( 0, stockIds.length );
 	var change = (randInRange( 1, 10 ) > 7 ? -1 : 1) *
 		(randInRange( 1, 10 ) / 1E2);
 


### PR DESCRIPTION
In chapter 9 demo project, you use a function randInRange to return a random stock index.
As The upper bound, you send stockIds.length - 1, though the upper bound is **exclusive**.
The proper upper bound should really be stockIds.length.

_### Note:_ Currently this small bug doesn't present any symptoms, coincidentally, due to another bug (See #160), that adds a redundant item to the array.
After the fix presented in #160, this bug causes the last stock to never receive any updates.