### PR TITLE
fix randInRange to be inclusive of the upper bound

### DIFF
--- a/ch11-code/mock-server.js
+++ b/ch11-code/mock-server.js
@@ -59,5 +59,5 @@ setTimeout( function randomStockUpdate(){
 
 // !!SIDE EFFECTS!!
 function randInRange(min = 0,max = 1E9) {
-	return (Math.round(Math.random() * 1E4) % (max - min)) + min;
+	return (Math.round(Math.random() * 1E4) % (max - min + 1)) + min;
 }


### PR DESCRIPTION
In continuation to the conversation in PR #161, This PR changes the randInRange to be inclusive of the upper bound as intended in its usages.