### PR TITLE
Fix curry ES6(arrow) implementation

### DIFF
--- a/manuscript/ch3.md
+++ b/manuscript/ch3.md
@@ -559,7 +559,7 @@ function curry(fn,arity = fn.length) {
 
 // or the ES6 => arrow form
 var curry =
-    (fn,arity = fn.length,nextCurried) =>
+    (fn,arity = fn.length) =>
         (nextCurried = prevArgs =>
             nextArg => {
                 var args = [ ...prevArgs, nextArg ];


### PR DESCRIPTION
It should only accept 2 parameters.

P.S: The current implementation has no problem in runtime though as nextCurried gets shadowed in the next line. But nevertheless it can be a source of confusion for readers.