### PR TITLE
Fix variable name

### DIFF
--- a/manuscript/ch8.md
+++ b/manuscript/ch8.md
@@ -439,9 +439,9 @@ function sum(num1,...nums) {
 }
 ```
 
-This isn't in PTC form because after the recursive call to `sum(...nums)` is finished, the `total` variable is added to that result. So, the stack frame has to be preserved to keep track of the `total` partial result while the rest of the recursion proceeds.
+This isn't in PTC form because after the recursive call to `sum(...nums)` is finished, the `num1` variable is added to that result. So, the stack frame has to be preserved to keep track of the `num1` partial result while the rest of the recursion proceeds.
 
-The key recognition point for this refactoring strategy is that we could remove our dependence on the stack by doing the addition *now* instead of *after*, and then forward-passing that partial result as an argument to the recursive call. In other words, instead of keeping `total` in the current function's stack frame, push it into the stack frame of the next recursive call; that frees up the current stack frame to be removed/reused.
+The key recognition point for this refactoring strategy is that we could remove our dependence on the stack by doing the addition *now* instead of *after*, and then forward-passing that partial result as an argument to the recursive call. In other words, instead of keeping `num1` in the current function's stack frame, push it into the stack frame of the next recursive call; that frees up the current stack frame to be removed/reused.
 
 To start, we could alter our `sum(..)` function's signature to have a new first parameter as the partial result:
 


### PR DESCRIPTION
Changed variable name in explanations (total) to match num1 in code snippet

**Yes, I promise I've read the [Contributions Guidelines](https://github.com/getify/Functional-Light-JS/blob/master/CONTRIBUTING.md)** (please feel free to remove this line -- if you leave this line here, I'm going to assume you didn't actually read it).
