### PR TITLE
strToUppercaseReducer is incorrect name

### DIFF
--- a/manuscript/apA.md
+++ b/manuscript/apA.md
@@ -187,7 +187,7 @@ function mapReducer(mapperFn) {
     };
 }
 
-var strToUppercaseReducer = mapReducer( strUppercase );
+var strUppercaseReducer = mapReducer( strUppercase );
 ```
 
 Our chain still looks the same:


### PR DESCRIPTION
Chapter starts out with name of function as `strUppercaseReducer` but has one instance there "To" is added - `strToUppercaseReducer`.

